### PR TITLE
feat: 데이터 관리 탭에 관리자 권한 추가

### DIFF
--- a/src/components/tabs/mypage.tsx
+++ b/src/components/tabs/mypage.tsx
@@ -73,6 +73,7 @@ export function MyPage({ onModalStateChange }: MyPageTabProps) {
                 onModalStateChange?.(true);
             },
             icon: <Settings className="w-5 h-5" />,
+            showOnlyForRole: '관리자' // 관리자만 보이도록
         },
     ];
 


### PR DESCRIPTION
- mypage.tsx: 데이터 관리 메뉴에 showOnlyForRole: '관리자' 추가
- 관리자가 아닌 사용자에게는 데이터 관리 탭 숨김 처리
- 기존 데이터 업로드와 동일한 권한 체크 로직 적용